### PR TITLE
feat: reinstate option to download files by DocRef ID

### DIFF
--- a/cgpclient/client.py
+++ b/cgpclient/client.py
@@ -204,6 +204,19 @@ class CGPFile:
             raise CGPClientException("Unexpected number of authors")
         return self._document_reference.author[0].identifier.value
 
+    @property
+    @typing.no_type_check
+    def ngis_category(self) -> str | None:
+        if self._document_reference.category:
+            for coding in self._document_reference.category:
+                for entry in coding.coding:
+                    if (
+                        entry.system
+                        == "https://genomicsengland.co.uk/ngis-file-category"
+                    ):
+                        return entry.code
+        return None
+
     def download_data(
         self,
         output: Path | None = None,
@@ -261,6 +274,7 @@ class CGPFiles:
         # columns to include for summary output
         short_cols: list[str] = [
             "last_updated",
+            "ngis_category",
             "content_type",
             "size",
             "author_ods_code",

--- a/cgpclient/scripts/download_file
+++ b/cgpclient/scripts/download_file
@@ -160,6 +160,7 @@ def main(cmdline_args: list[str]) -> None:
         file_id=args.file_id,
         ods_code=args.ods_code,
         workspace_id=args.workspace_id,
+        document_reference_id=args.document_reference,
     )
 
     client: CGPClient = CGPClient(

--- a/cgpclient/scripts/list_files
+++ b/cgpclient/scripts/list_files
@@ -29,6 +29,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         type=str,
         help="NGIS participant ID, e.g p12345678303",
     )
+    parser.add_argument(
+        "-n",
+        "--nhs_number",
+        type=str,
+        help="NHS number for patient",
+    )
     parser.add_argument("-s", "--sample_id", type=str, help="Sample identifier")
     parser.add_argument(
         "-id",
@@ -192,6 +198,7 @@ def main(cmdline_args: list[str]) -> None:
         run_id=args.run_id,
         sample_id=args.sample_id,
         workspace_id=args.workspace_id,
+        nhs_number=args.nhs_number,
     )
 
     client: CGPClient = CGPClient(


### PR DESCRIPTION
Bring back the -d command line parameter to download_file so you can download a specific file using the DocumentReference ID (with or without the DocumentReference/ prefix). This uses the _id search parameter and so avoids an issue with direct GETs on resource IDs in APIM (perhaps at a slight cost in efficiency)